### PR TITLE
Add status and fundingStatus to FxSummary

### DIFF
--- a/src/main/java/com/velopayments/api/model/payout/v3/FxSummary.java
+++ b/src/main/java/com/velopayments/api/model/payout/v3/FxSummary.java
@@ -23,6 +23,9 @@ public class FxSummary {
     private ZonedDateTime expiryTime;
     private UUID quoteId;
     private Long totalSourceAmount;
+    private Long totalPaymentAmount;
+    private String sourceCurrency;
+    private String paymentCurrency;
     private QuoteStatus status;
     private PaymentStatus fundingStatus;
 

--- a/src/main/java/com/velopayments/api/model/payout/v3/FxSummary.java
+++ b/src/main/java/com/velopayments/api/model/payout/v3/FxSummary.java
@@ -1,5 +1,7 @@
 package com.velopayments.api.model.payout.v3;
 
+import com.velopayments.api.model.paymentaudit.v3.PaymentStatus;
+import com.velopayments.api.model.paymentaudit.v3.QuoteStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,8 +23,7 @@ public class FxSummary {
     private ZonedDateTime expiryTime;
     private UUID quoteId;
     private Long totalSourceAmount;
-    private Long totalPaymentAmount;
-    private String sourceCurrency;
-    private String paymentCurrency;
+    private QuoteStatus status;
+    private PaymentStatus fundingStatus;
 
 }


### PR DESCRIPTION
The current version of the Velo Payments API (2.18.110 at the time of this PR) shows there are two more fields available on `FxSummary` than what is in the model. [Quote Payout API](https://apidocs.velopayments.com/#tag/Quote-Payout)

This may have been missed as this `FxSummary` looks to be a duplicate of the one in `com.velopayments.api.model.paymentaudit.v3`. Should they be combined?
